### PR TITLE
feat: inject $segment into nuxt context

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ This module uses [vue-segment](https://github.com/dansmaculotte/vue-segment) to 
 
 ## Usage
 
+Inside a Vue component, the Segment `analytics` object is available as `this.$segment`:
+
 ```js
 export default {
   mounted () {
@@ -70,6 +72,21 @@ export default {
   }
 }
 ```
+
+`$segment` is also injected into the [Nuxt context](https://nuxtjs.org/api/context/) so you can access it within your Vuex stores:
+
+```js
+export default {
+  LOGOUT({ dispatch }) {
+    return this.$auth.logout()
+      .then(() => {
+        this.$segment.reset()
+        return this.dispatch('AFTER_LOGOUT')
+      })
+  }
+}
+```
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ export default {
   LOGOUT({ dispatch }) {
     return this.$auth.logout()
       .then(() => {
-        this.$segment.reset()
-        return this.dispatch('AFTER_LOGOUT')
+        this.$segment.reset();
+        return this.dispatch('AFTER_LOGOUT');
       })
   }
 }

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ export default {
     return this.$auth.logout()
       .then(() => {
         this.$segment.reset();
-        return this.dispatch('AFTER_LOGOUT');
+        return dispatch('AFTER_LOGOUT');
       })
   }
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -6,7 +6,7 @@ const SEGMENT_DISABLED = <%= options.disabled %>
 const SEGMENT_USE_ROUTER = <%= options.useRouter %>
 const SEGMENT_SETTINGS = <%= JSON.stringify(options.settings) %>
 
-export default function ({ app }) {
+export default function (context, inject) {
 
   const options = {
     writeKey: SEGMENT_WRITE_KEY,
@@ -15,8 +15,17 @@ export default function ({ app }) {
   }
 
   if (SEGMENT_USE_ROUTER) {
-    options.router = app.router;
+    options.router = context.app.router
   }
 
   Vue.use(Segment, options)
+
+  return new Promise((resolve) => {
+    Vue.$segment.ready(() => {
+      context.$segment = Vue.$segment
+      inject('segment', Vue.$segment)
+      resolve()
+    })
+  })
+
 }


### PR DESCRIPTION
I needed access to `$segment` inside of my vuex store, but I noticed it wasn't being injected using [the combined `inject` method](https://nuxtjs.org/guide/plugins/#combined-inject). In this PR, I've added context injection using [nuxt-community/analytics-module](https://github.com/nuxt-community/analytics-module/blob/master/lib/plugin.js) as an example.

Note that I also had to wrap the injection in a `$segment.ready()` handler. Without that, `Vue.$segment` appears to just be [an empty array](https://github.com/dansmaculotte/vue-segment/blob/master/src/index.js#L8) until analytics.js is loaded.

I'm not 100% sure if this is the best way to do this, but I've tested it locally and it appears to work just fine!