### PR TITLE
feat(config): adding support of public runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ This module uses [vue-segment](https://github.com/dansmaculotte/vue-segment) to 
   // Or with publicRuntimeConfig
 
   publicRuntimeConfig: {
-    SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY || '',
-    SEGMENT_DISABLED: process.env.SEGMENT_DISABLED || false,
-    SEGMENT_USE_ROUTER: process.env.SEGMENT_USE_ROUTER || true,
+    SEGMENT_WRITE_KEY: '',
+    SEGMENT_DISABLED: false,
+    SEGMENT_USE_ROUTER: true,
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ This module uses [vue-segment](https://github.com/dansmaculotte/vue-segment) to 
     disabled: false,
     useRouter: true
   }
+
+  // Or with publicRuntimeConfig
+
+  publicRuntimeConfig: {
+    SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY || '',
+    SEGMENT_DISABLED: process.env.SEGMENT_DISABLED || false,
+    SEGMENT_USE_ROUTER: process.env.SEGMENT_USE_ROUTER || true,
+  }
 }
 ```
 
@@ -44,17 +52,17 @@ This module uses [vue-segment](https://github.com/dansmaculotte/vue-segment) to 
 ### writeKey
 
 - Type: `String`
-  - Default: `process.env.SEGMENT_WRITE_KEY || ''`
+  - Default: `process.env.SEGMENT_WRITE_KEY || publicRuntimeConfig.SEGMENT_WRITE_KEY`
 
 ### disabled
 
 - Type: `Boolean`
-  - Default: `process.env.SEGMENT_DISABLED || false`
+  - Default: `process.env.SEGMENT_DISABLED || publicRuntimeConfig.SEGMENT_DISABLED || false`
 
 ### useRouter
 
 - Type: `Boolean`
-  - Default: `process.env.SEGMENT_USE_ROUTER || true`
+  - Default: `process.env.SEGMENT_USE_ROUTER || publicRuntimeConfig.SEGMENT_USE_ROUTER || true`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ This module uses [vue-segment](https://github.com/dansmaculotte/vue-segment) to 
   // Or with publicRuntimeConfig
 
   publicRuntimeConfig: {
-    SEGMENT_WRITE_KEY: '',
-    SEGMENT_DISABLED: false,
-    SEGMENT_USE_ROUTER: true,
+    SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY_FROM_SERVER || '',
+    SEGMENT_DISABLED: process.env.SEGMENT_DISBLED_FROM_SERVER || false,
+    SEGMENT_USE_ROUTER: process.env.SEGMENT_USE_ROUTER_FROM_SERVER || true,
   }
 }
 ```

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,22 +1,24 @@
 const { resolve } = require('path')
 
 export default function (moduleOptions) {
+  const { publicRuntimeConfig } = this.nuxt.options
+
   const options = Object.assign(
     {
-      writeKey: process.env.SEGMENT_WRITE_KEY || '',
-      disabled: process.env.SEGMENT_DISABLED || false,
-      useRouter: process.env.SEGMENT_USE_ROUTER || true,
-      settings: {}
+      writeKey: process.env.SEGMENT_WRITE_KEY || publicRuntimeConfig.SEGMENT_WRITE_KEY,
+      disabled: process.env.SEGMENT_DISABLED || publicRuntimeConfig.SEGMENT_DISABLED || false,
+      useRouter: process.env.SEGMENT_USE_ROUTER || publicRuntimeConfig.SEGMENT_USE_ROUTER || true,
+      settings: {},
     },
     this.options.segment,
-    moduleOptions
+    moduleOptions,
   )
 
   const pluginOpts = {
     src: resolve(__dirname, 'plugin.js'),
     fileName: 'nuxt-segment.js',
     ssr: false,
-    options
+    options,
   }
 
   this.addPlugin(pluginOpts)

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,13 +1,11 @@
 const { resolve } = require('path')
 
 export default function (moduleOptions) {
-  const { publicRuntimeConfig } = this.nuxt.options
-
   const options = Object.assign(
     {
-      writeKey: process.env.SEGMENT_WRITE_KEY || publicRuntimeConfig.SEGMENT_WRITE_KEY,
-      disabled: process.env.SEGMENT_DISABLED || publicRuntimeConfig.SEGMENT_DISABLED || false,
-      useRouter: process.env.SEGMENT_USE_ROUTER || publicRuntimeConfig.SEGMENT_USE_ROUTER || true,
+      writeKey: process.env.SEGMENT_WRITE_KEY,
+      disabled: process.env.SEGMENT_DISABLED,
+      useRouter: process.env.SEGMENT_USE_ROUTER,
       settings: {},
     },
     this.options.segment,

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,21 +1,20 @@
 import Vue from 'vue'
 import Segment from '@dansmaculotte/vue-segment'
 
-const SEGMENT_WRITE_KEY = '<%= options.writeKey %>'
-const SEGMENT_DISABLED = <%= options.disabled %>
-const SEGMENT_USE_ROUTER = <%= options.useRouter %>
-const SEGMENT_SETTINGS = <%= JSON.stringify(options.settings) %>
+const OPTIONS = '<%= JSON.stringify(options) %>'
 
 export default function (context, inject) {
   const { app, store } = context
 
+  const moduleOptions = JSON.parse(OPTIONS)
+
   const options = {
-    writeKey: SEGMENT_WRITE_KEY,
-    disabled: SEGMENT_DISABLED,
-    settings: SEGMENT_SETTINGS
+    writeKey: moduleOptions.writeKey,
+    disabled: moduleOptions.disabled,
+    settings: moduleOptions.settings,
   }
 
-  if (SEGMENT_USE_ROUTER && app.router) {
+  if (options.useRouter && app.router) {
     options.router = app.router
   }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,20 +1,31 @@
 import Vue from 'vue'
 import Segment from '@dansmaculotte/vue-segment'
 
+function checkIfBoolean (param) {
+  return typeof param === 'boolean'
+}
+
 const OPTIONS = '<%= JSON.stringify(options) %>'
 
 export default function (context, inject) {
-  const { app, store } = context
+  const { app, store, $config } = context
 
   const moduleOptions = JSON.parse(OPTIONS)
 
   const options = {
-    writeKey: moduleOptions.writeKey,
-    disabled: moduleOptions.disabled,
+    writeKey: moduleOptions.writeKey || ($config && $config.SEGMENT_WRITE_KEY),
+    disabled: moduleOptions.disabled || ($config && $config.SEGMENT_DISABLED) || false,
     settings: moduleOptions.settings,
   }
 
-  if (options.useRouter && app.router) {
+  const useRouter =
+    checkIfBoolean(moduleOptions.useRouter)
+      ? moduleOptions.useRouter
+      : checkIfBoolean($config.SEGMENT_USE_ROUTER)
+        ? $config.SEGMENT_USE_ROUTER
+        : true
+
+  if (useRouter && app.router) {
     options.router = app.router
   }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,8 +1,22 @@
 import Vue from 'vue'
 import Segment from '@dansmaculotte/vue-segment'
 
+const DEFAULT_USE_ROUTER = true
+
 function checkIfBoolean (param) {
   return typeof param === 'boolean'
+}
+
+function moduleOptionRouter(moduleOptions) {
+  return checkIfBoolean(moduleOptions.useRouter) ? moduleOptions.useRouter : undefined
+}
+
+function configOptionRouter($config) {
+  return checkIfBoolean($config.SEGMENT_USE_ROUTER) ? $config.SEGMENT_USE_ROUTER : undefined
+}
+
+function shouldUseRouter(moduleOptions, $config) {
+  return moduleOptionRouter(moduleOptions) || configOptionRouter($config) || DEFAULT_USE_ROUTER
 }
 
 const OPTIONS = '<%= JSON.stringify(options) %>'
@@ -18,12 +32,7 @@ export default function (context, inject) {
     settings: moduleOptions.settings,
   }
 
-  const useRouter =
-    checkIfBoolean(moduleOptions.useRouter)
-      ? moduleOptions.useRouter
-      : checkIfBoolean($config.SEGMENT_USE_ROUTER)
-        ? $config.SEGMENT_USE_ROUTER
-        : true
+  const useRouter = shouldUseRouter(moduleOptions, $config)
 
   if (useRouter && app.router) {
     options.router = app.router


### PR DESCRIPTION
# Why ? 

- I have to specify the environment variables on my server to use different keys depending on the environment (`STAGING`,` PREPROD`, `PRODUCTION`, etc.)
- Useful to not use `dot-env` or something like that
 
# Changelog

- The plugin check if `SEGMENT_**` environements vars are availables in `publicRuntimeConfig` (from `context.$config`)
